### PR TITLE
Fix HiDPI on macOS (and possibly others?)

### DIFF
--- a/src/Editor/CBasicViewport.cpp
+++ b/src/Editor/CBasicViewport.cpp
@@ -49,7 +49,8 @@ void CBasicViewport::initializeGL()
 void CBasicViewport::paintGL()
 {
     // Prep render
-    glViewport(0, 0, width(), height());
+    float scale = devicePixelRatioF();
+    glViewport(0, 0, (int)((float)width() * scale), (int)((float)height() * scale));
     glLineWidth(1.f);
     glEnable(GL_DEPTH_TEST);
     mViewInfo.ViewFrustum = mCamera.FrustumPlanes();
@@ -67,7 +68,8 @@ void CBasicViewport::paintGL()
 void CBasicViewport::resizeGL(int Width, int Height)
 {
     mCamera.SetAspectRatio((float) Width / Height);
-    glViewport(0, 0, Width, Height);
+    float scale = devicePixelRatioF();
+    glViewport(0, 0, (int)((float)Width * scale), (int)((float)Height * scale));
     OnResize();
 }
 


### PR DESCRIPTION
This calls into Application to get the scaling factor for the monitor the app is currently on. It does not currently automatically fix when switching monitors with differing DPI, it requires a resize to properly scale.